### PR TITLE
Fixed API endpoint for prod builds

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -37,7 +37,7 @@
     "production": {
       "autoIncrement": true,
       "env": {
-        "EXPO_PUBLIC_API_URL": "https://prayerloop.io"
+        "EXPO_PUBLIC_API_URL": "https://dev.prayerloop.io"
       }
     }
   },


### PR DESCRIPTION
Accidentally had the wrong endpoint.  Eventually there will be a "prayerloop.io" URL, but for now, the correct URL is appended with "dev"